### PR TITLE
⚡️ Increase file download concurrency from 1 to 3

### DIFF
--- a/src/cozy/pronote/grades.js
+++ b/src/cozy/pronote/grades.js
@@ -114,7 +114,7 @@ async function saveReports(pronote, fields) {
   const data = await saveFiles(filesToDownload, fields, {
     sourceAccount: this.accountId,
     sourceAccountIdentifier: fields.login,
-    concurrency: 1,
+    concurrency: 3,
     validateFile: () => true
   })
 
@@ -191,7 +191,7 @@ async function createGrades(pronote, fields, options) {
         const data = await saveFiles(filesToDownload, fields, {
           sourceAccount: this.accountId,
           sourceAccountIdentifier: fields.login,
-          concurrency: 1,
+          concurrency: 3,
           validateFile: () => true
         })
 
@@ -241,7 +241,7 @@ async function createGrades(pronote, fields, options) {
         const data = await saveFiles(filesToDownload, fields, {
           sourceAccount: this.accountId,
           sourceAccountIdentifier: fields.login,
-          concurrency: 1,
+          concurrency: 3,
           validateFile: () => true
         })
 

--- a/src/cozy/pronote/homeworks.js
+++ b/src/cozy/pronote/homeworks.js
@@ -96,7 +96,7 @@ async function createHomeworks(pronote, fields, options) {
         const data = await saveFiles(filesToDownload, fields, {
           sourceAccount: this.accountId,
           sourceAccountIdentifier: fields.login,
-          concurrency: 1,
+          concurrency: 3,
           validateFile: () => true
         })
 

--- a/src/cozy/pronote/identity.js
+++ b/src/cozy/pronote/identity.js
@@ -119,7 +119,7 @@ async function save_profile_picture(pronote, fields) {
   const files = await saveFiles(documents, fields, {
     sourceAccount: this.accountId,
     sourceAccountIdentifier: fields.login,
-    concurrency: 1,
+    concurrency: 3,
     validateFile: () => true
   })
 

--- a/src/utils/stack/save_resources.js
+++ b/src/utils/stack/save_resources.js
@@ -81,7 +81,7 @@ URL=${file.url}`.trim()
     const data = await saveFiles(filesToDownload, fields, {
       sourceAccount: this.accountId,
       sourceAccountIdentifier: fields.login,
-      concurrency: 1,
+      concurrency: 3,
       validateFile: () => true
     })
 


### PR DESCRIPTION
## Changes
This PR changes all `saveFiles()` download concurrency from `1` to `3` to allow the cozy prod stack to handle files simultaneously.