### PR TITLE
feat: Add qualification labels to file uploads

### DIFF
--- a/src/cozy/pronote/grades.js
+++ b/src/cozy/pronote/grades.js
@@ -115,6 +115,7 @@ async function saveReports(pronote, fields) {
     sourceAccount: this.accountId,
     sourceAccountIdentifier: fields.login,
     concurrency: 3,
+    qualificationLabel: 'gradebook', // Grade report
     validateFile: () => true
   })
 
@@ -192,6 +193,7 @@ async function createGrades(pronote, fields, options) {
           sourceAccount: this.accountId,
           sourceAccountIdentifier: fields.login,
           concurrency: 3,
+          qualificationLabel: 'other_work_document', // Given subject
           validateFile: () => true
         })
 
@@ -242,6 +244,7 @@ async function createGrades(pronote, fields, options) {
           sourceAccount: this.accountId,
           sourceAccountIdentifier: fields.login,
           concurrency: 3,
+          qualificationLabel: 'other_work_document', // Corrected subject
           validateFile: () => true
         })
 

--- a/src/cozy/pronote/homeworks.js
+++ b/src/cozy/pronote/homeworks.js
@@ -97,6 +97,7 @@ async function createHomeworks(pronote, fields, options) {
           sourceAccount: this.accountId,
           sourceAccountIdentifier: fields.login,
           concurrency: 3,
+          qualificationLabel: 'other_work_document', // Homework subject
           validateFile: () => true
         })
 

--- a/src/cozy/pronote/identity.js
+++ b/src/cozy/pronote/identity.js
@@ -95,7 +95,7 @@ async function format_json(pronote, information, profile_pic) {
     relationships: profile_pic &&
       profile_pic['_id'] && {
         picture: {
-          // photo de profil
+          // Profile picture
           data: { _id: profile_pic['_id'], _type: 'io.cozy.files' }
         }
       }
@@ -120,7 +120,7 @@ async function save_profile_picture(pronote, fields) {
     sourceAccount: this.accountId,
     sourceAccountIdentifier: fields.login,
     concurrency: 3,
-    qualificationLabel: 'identity_photo', // Photo de classe
+    qualificationLabel: 'identity_photo', // Class photo
     validateFile: () => true
   })
 

--- a/src/cozy/pronote/identity.js
+++ b/src/cozy/pronote/identity.js
@@ -120,6 +120,7 @@ async function save_profile_picture(pronote, fields) {
     sourceAccount: this.accountId,
     sourceAccountIdentifier: fields.login,
     concurrency: 3,
+    qualificationLabel: 'identity_photo', // Photo de classe
     validateFile: () => true
   })
 


### PR DESCRIPTION
Added qualification labels to saved documents in the cozy stack.

| Type of document | Qualification |
| -- | -- |
| Grade report | `gradebook` |
| Photo de classe | `identity_photo` |
| Subjects and corrected files | `other_work_document` |